### PR TITLE
Understands --isolate flag now

### DIFF
--- a/src/vows.js
+++ b/src/vows.js
@@ -28,6 +28,7 @@ exports.init  = function (grunt) {
             getTestsToRun(),
             getFlag("verbose"),
             getFlag("silent"),
+            getFlag("isolate"),
             getColorFlag()
         ].filter(function (entry) {
             return entry !== null;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -304,6 +304,7 @@ exports.helpers = VOWS.describe("grunt-vows helpers")
                             reporter: "tap",
                             onlyRun: "helper",
                             verbose: true,
+                            isolate: true,
                             silent: true
                         }
                     }
@@ -341,6 +342,9 @@ exports.helpers = VOWS.describe("grunt-vows helpers")
 
             "should include '--color' flag by default": function (topic) {
                 ASSERT.match(topic, /\s--color/);
+            },
+            "should include 'isolate' flag when specified": function (topic) {
+                ASSERT.match(topic, /\s--isolate\s/);
             }
         }
     });


### PR DESCRIPTION
vows has an "--isolate" flag that wasn't understood by grunt-vows. I've added it.
