### PR TITLE
Can specify options to specify coverage output format when using node-jscoverage

### DIFF
--- a/src/vows.js
+++ b/src/vows.js
@@ -29,7 +29,8 @@ exports.init  = function (grunt) {
             getFlag("verbose"),
             getFlag("silent"),
             getColorFlag(),
-            getCoverageFormat()
+            getCoverageFormat(),
+            getFlag("isolate")
         ].filter(function (entry) {
             return entry !== null;
         }).join(" ");

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -304,6 +304,7 @@ exports.helpers = VOWS.describe("grunt-vows helpers")
                             reporter: "tap",
                             onlyRun: "helper",
                             verbose: true,
+                            isolate: true,
                             silent: true
                         }
                     }
@@ -341,6 +342,9 @@ exports.helpers = VOWS.describe("grunt-vows helpers")
 
             "should include '--color' flag by default": function (topic) {
                 ASSERT.match(topic, /\s--color/);
+            },
+            "should include 'isolate' flag when specified": function (topic) {
+                ASSERT.match(topic, /\s--isolate\s/);
             }
         }
     });


### PR DESCRIPTION
Can specify text/html/json as coverageOutput when using node-jscoverage, like so:

vows:
        {
            all:
            {
                // String or array of strings
                // determining which files to include
                files: ["test/*_/_.js"],
                // String {spec|json|dot-matrix|xunit|tap}
                // defaults to "dot-matrix"
                reporter: "spec",
                verbose: false,
                silent: false,
                isolate: true,
                colors: true,
                coverageOutput: "html"
            }
        }
